### PR TITLE
feat: implement DoT, DoQ and bootstrap IP support

### DIFF
--- a/dnsstamps.go
+++ b/dnsstamps.go
@@ -13,6 +13,7 @@ import (
 
 const (
 	DefaultPort    = 443
+	DefaultDoTPort = 853
 	DefaultDNSPort = 53
 	StampScheme    = "sdns://"
 )
@@ -69,6 +70,7 @@ type ServerStamp struct {
 	Path          string
 	Props         ServerInformalProperties
 	Proto         StampProtoType
+	BootstrapIPs  []string
 }
 
 func NewDNSCryptServerStampFromLegacy(serverAddrStr string, serverPkStr string, providerName string, props ServerInformalProperties) (ServerStamp, error) {
@@ -108,6 +110,10 @@ func NewServerStampFromString(stampStr string) (ServerStamp, error) {
 		return newDNSCryptServerStamp(bin)
 	} else if bin[0] == uint8(StampProtoTypeDoH) {
 		return newDoHServerStamp(bin)
+	} else if bin[0] == uint8(StampProtoTypeTLS) {
+		return newDoTServerStamp(bin)
+	} else if bin[0] == uint8(StampProtoTypeDoQ) {
+		return newDoQServerStamp(bin)
 	} else if bin[0] == uint8(StampProtoTypeODoHTarget) {
 		return newODoHTargetStamp(bin)
 	} else if bin[0] == uint8(StampProtoTypeDNSCryptRelay) {
@@ -299,6 +305,29 @@ func newDoHServerStamp(bin []byte) (ServerStamp, error) {
 	stamp.Path = string(bin[pos : pos+length])
 	pos += length
 
+	// Parse optional bootstrap IP addresses (VLP format)
+	if pos < binLen {
+		for {
+			if pos >= binLen {
+				break
+			}
+			vlen := int(bin[pos])
+			length = vlen & ^0x80
+			if 1+length > binLen-pos {
+				return stamp, errors.New("Invalid stamp")
+			}
+			pos++
+			if length > 0 {
+				bootstrapIP := string(bin[pos : pos+length])
+				stamp.BootstrapIPs = append(stamp.BootstrapIPs, bootstrapIP)
+			}
+			pos += length
+			if vlen&0x80 != 0x80 {
+				break
+			}
+		}
+	}
+
 	if pos != binLen {
 		return stamp, errors.New("Invalid stamp (garbage after end)")
 	}
@@ -321,6 +350,196 @@ func newDoHServerStamp(bin []byte) (ServerStamp, error) {
 			return stamp, errors.New("Invalid stamp (port range)")
 		}
 		if net.ParseIP(strings.TrimRight(strings.TrimLeft(ipOnly, "["), "]")) == nil {
+			return stamp, errors.New("Invalid stamp (IP address)")
+		}
+	}
+
+	return stamp, nil
+}
+
+// id(u8)=0x03 props addrLen(1) serverAddr hashLen(1) hash hostNameLen(1) hostName [ bootstrapLen(1) bootstrap ]
+
+func newDoTServerStamp(bin []byte) (ServerStamp, error) {
+	stamp := ServerStamp{Proto: StampProtoTypeTLS}
+	if len(bin) < 13 {
+		return stamp, errors.New("Stamp is too short")
+	}
+	stamp.Props = ServerInformalProperties(binary.LittleEndian.Uint64(bin[1:9]))
+	binLen := len(bin)
+	pos := 9
+
+	length := int(bin[pos])
+	if 1+length >= binLen-pos {
+		return stamp, errors.New("Invalid stamp")
+	}
+	pos++
+	stamp.ServerAddrStr = string(bin[pos : pos+length])
+	pos += length
+
+	for {
+		vlen := int(bin[pos])
+		length = vlen & ^0x80
+		if 1+length >= binLen-pos {
+			return stamp, errors.New("Invalid stamp")
+		}
+		pos++
+		if length > 0 {
+			stamp.Hashes = append(stamp.Hashes, bin[pos:pos+length])
+		}
+		pos += length
+		if vlen&0x80 != 0x80 {
+			break
+		}
+	}
+
+	length = int(bin[pos])
+	if length >= binLen-pos {
+		return stamp, errors.New("Invalid stamp")
+	}
+	pos++
+	stamp.ProviderName = string(bin[pos : pos+length])
+	pos += length
+
+	// Parse optional bootstrap IP addresses (VLP format)
+	if pos < binLen {
+		for {
+			if pos >= binLen {
+				break
+			}
+			vlen := int(bin[pos])
+			length = vlen & ^0x80
+			if 1+length > binLen-pos {
+				return stamp, errors.New("Invalid stamp")
+			}
+			pos++
+			if length > 0 {
+				bootstrapIP := string(bin[pos : pos+length])
+				stamp.BootstrapIPs = append(stamp.BootstrapIPs, bootstrapIP)
+			}
+			pos += length
+			if vlen&0x80 != 0x80 {
+				break
+			}
+		}
+	}
+
+	if pos != binLen {
+		return stamp, errors.New("Invalid stamp (garbage after end)")
+	}
+
+	if len(stamp.ServerAddrStr) > 0 {
+		colIndex := strings.LastIndex(stamp.ServerAddrStr, ":")
+		bracketIndex := strings.LastIndex(stamp.ServerAddrStr, "]")
+		if colIndex < bracketIndex {
+			colIndex = -1
+		}
+		if colIndex < 0 {
+			colIndex = len(stamp.ServerAddrStr)
+			stamp.ServerAddrStr = fmt.Sprintf("%s:%d", stamp.ServerAddrStr, DefaultDoTPort)
+		}
+		if colIndex >= len(stamp.ServerAddrStr)-1 {
+			return stamp, errors.New("Invalid stamp (empty port)")
+		}
+		ipOnly := stamp.ServerAddrStr[:colIndex]
+		if err := validatePort(stamp.ServerAddrStr[colIndex+1:]); err != nil {
+			return stamp, errors.New("Invalid stamp (port range)")
+		}
+		if ipOnly != "" && net.ParseIP(strings.TrimRight(strings.TrimLeft(ipOnly, "["), "]")) == nil {
+			return stamp, errors.New("Invalid stamp (IP address)")
+		}
+	}
+
+	return stamp, nil
+}
+
+// id(u8)=0x04 props addrLen(1) serverAddr hashLen(1) hash hostNameLen(1) hostName [ bootstrapLen(1) bootstrap ]
+
+func newDoQServerStamp(bin []byte) (ServerStamp, error) {
+	stamp := ServerStamp{Proto: StampProtoTypeDoQ}
+	if len(bin) < 13 {
+		return stamp, errors.New("Stamp is too short")
+	}
+	stamp.Props = ServerInformalProperties(binary.LittleEndian.Uint64(bin[1:9]))
+	binLen := len(bin)
+	pos := 9
+
+	length := int(bin[pos])
+	if 1+length >= binLen-pos {
+		return stamp, errors.New("Invalid stamp")
+	}
+	pos++
+	stamp.ServerAddrStr = string(bin[pos : pos+length])
+	pos += length
+
+	for {
+		vlen := int(bin[pos])
+		length = vlen & ^0x80
+		if 1+length >= binLen-pos {
+			return stamp, errors.New("Invalid stamp")
+		}
+		pos++
+		if length > 0 {
+			stamp.Hashes = append(stamp.Hashes, bin[pos:pos+length])
+		}
+		pos += length
+		if vlen&0x80 != 0x80 {
+			break
+		}
+	}
+
+	length = int(bin[pos])
+	if length >= binLen-pos {
+		return stamp, errors.New("Invalid stamp")
+	}
+	pos++
+	stamp.ProviderName = string(bin[pos : pos+length])
+	pos += length
+
+	// Parse optional bootstrap IP addresses (VLP format)
+	if pos < binLen {
+		for {
+			if pos >= binLen {
+				break
+			}
+			vlen := int(bin[pos])
+			length = vlen & ^0x80
+			if 1+length > binLen-pos {
+				return stamp, errors.New("Invalid stamp")
+			}
+			pos++
+			if length > 0 {
+				bootstrapIP := string(bin[pos : pos+length])
+				stamp.BootstrapIPs = append(stamp.BootstrapIPs, bootstrapIP)
+			}
+			pos += length
+			if vlen&0x80 != 0x80 {
+				break
+			}
+		}
+	}
+
+	if pos != binLen {
+		return stamp, errors.New("Invalid stamp (garbage after end)")
+	}
+
+	if len(stamp.ServerAddrStr) > 0 {
+		colIndex := strings.LastIndex(stamp.ServerAddrStr, ":")
+		bracketIndex := strings.LastIndex(stamp.ServerAddrStr, "]")
+		if colIndex < bracketIndex {
+			colIndex = -1
+		}
+		if colIndex < 0 {
+			colIndex = len(stamp.ServerAddrStr)
+			stamp.ServerAddrStr = fmt.Sprintf("%s:%d", stamp.ServerAddrStr, DefaultDoTPort)
+		}
+		if colIndex >= len(stamp.ServerAddrStr)-1 {
+			return stamp, errors.New("Invalid stamp (empty port)")
+		}
+		ipOnly := stamp.ServerAddrStr[:colIndex]
+		if err := validatePort(stamp.ServerAddrStr[colIndex+1:]); err != nil {
+			return stamp, errors.New("Invalid stamp (port range)")
+		}
+		if ipOnly != "" && net.ParseIP(strings.TrimRight(strings.TrimLeft(ipOnly, "["), "]")) == nil {
 			return stamp, errors.New("Invalid stamp (IP address)")
 		}
 	}
@@ -455,6 +674,29 @@ func newODoHRelayStamp(bin []byte) (ServerStamp, error) {
 	stamp.Path = string(bin[pos : pos+length])
 	pos += length
 
+	// Parse optional bootstrap IP addresses (VLP format)
+	if pos < binLen {
+		for {
+			if pos >= binLen {
+				break
+			}
+			vlen := int(bin[pos])
+			length = vlen & ^0x80
+			if 1+length > binLen-pos {
+				return stamp, errors.New("Invalid stamp")
+			}
+			pos++
+			if length > 0 {
+				bootstrapIP := string(bin[pos : pos+length])
+				stamp.BootstrapIPs = append(stamp.BootstrapIPs, bootstrapIP)
+			}
+			pos += length
+			if vlen&0x80 != 0x80 {
+				break
+			}
+		}
+	}
+
 	if pos != binLen {
 		return stamp, errors.New("Invalid stamp (garbage after end)")
 	}
@@ -485,7 +727,8 @@ func newODoHRelayStamp(bin []byte) (ServerStamp, error) {
 }
 
 func validatePort(port string) error {
-	if _, err := strconv.ParseUint(port, 10, 16); err != nil {
+	p, err := strconv.ParseUint(port, 10, 16)
+	if err != nil || p == 0 {
 		return errors.New("Invalid port")
 	}
 	return nil
@@ -498,6 +741,10 @@ func (stamp *ServerStamp) String() string {
 		return stamp.dnsCryptString()
 	} else if stamp.Proto == StampProtoTypeDoH {
 		return stamp.dohString()
+	} else if stamp.Proto == StampProtoTypeTLS {
+		return stamp.dotString()
+	} else if stamp.Proto == StampProtoTypeDoQ {
+		return stamp.doqString()
 	} else if stamp.Proto == StampProtoTypeODoHTarget {
 		return stamp.oDohTargetString()
 	} else if stamp.Proto == StampProtoTypeDNSCryptRelay {
@@ -579,6 +826,113 @@ func (stamp *ServerStamp) dohString() string {
 	bin = append(bin, uint8(len(stamp.Path)))
 	bin = append(bin, []uint8(stamp.Path)...)
 
+	// Serialize optional bootstrap IP addresses (VLP format)
+	if len(stamp.BootstrapIPs) > 0 {
+		last := len(stamp.BootstrapIPs) - 1
+		for i, bootstrapIP := range stamp.BootstrapIPs {
+			vlen := len(bootstrapIP)
+			if i < last {
+				vlen |= 0x80
+			}
+			bin = append(bin, uint8(vlen))
+			bin = append(bin, []uint8(bootstrapIP)...)
+		}
+	}
+
+	str := base64.RawURLEncoding.EncodeToString(bin)
+
+	return StampScheme + str
+}
+
+func (stamp *ServerStamp) dotString() string {
+	bin := make([]uint8, 9)
+	bin[0] = uint8(StampProtoTypeTLS)
+	binary.LittleEndian.PutUint64(bin[1:9], uint64(stamp.Props))
+
+	serverAddrStr := stamp.ServerAddrStr
+	if strings.HasSuffix(serverAddrStr, ":"+strconv.Itoa(DefaultDoTPort)) {
+		serverAddrStr = serverAddrStr[:len(serverAddrStr)-1-len(strconv.Itoa(DefaultDoTPort))]
+	}
+	bin = append(bin, uint8(len(serverAddrStr)))
+	bin = append(bin, []uint8(serverAddrStr)...)
+
+	if len(stamp.Hashes) == 0 {
+		bin = append(bin, uint8(0))
+	} else {
+		last := len(stamp.Hashes) - 1
+		for i, hash := range stamp.Hashes {
+			vlen := len(hash)
+			if i < last {
+				vlen |= 0x80
+			}
+			bin = append(bin, uint8(vlen))
+			bin = append(bin, hash...)
+		}
+	}
+
+	bin = append(bin, uint8(len(stamp.ProviderName)))
+	bin = append(bin, []uint8(stamp.ProviderName)...)
+
+	// Serialize optional bootstrap IP addresses (VLP format)
+	if len(stamp.BootstrapIPs) > 0 {
+		last := len(stamp.BootstrapIPs) - 1
+		for i, bootstrapIP := range stamp.BootstrapIPs {
+			vlen := len(bootstrapIP)
+			if i < last {
+				vlen |= 0x80
+			}
+			bin = append(bin, uint8(vlen))
+			bin = append(bin, []uint8(bootstrapIP)...)
+		}
+	}
+
+	str := base64.RawURLEncoding.EncodeToString(bin)
+
+	return StampScheme + str
+}
+
+func (stamp *ServerStamp) doqString() string {
+	bin := make([]uint8, 9)
+	bin[0] = uint8(StampProtoTypeDoQ)
+	binary.LittleEndian.PutUint64(bin[1:9], uint64(stamp.Props))
+
+	serverAddrStr := stamp.ServerAddrStr
+	if strings.HasSuffix(serverAddrStr, ":"+strconv.Itoa(DefaultDoTPort)) {
+		serverAddrStr = serverAddrStr[:len(serverAddrStr)-1-len(strconv.Itoa(DefaultDoTPort))]
+	}
+	bin = append(bin, uint8(len(serverAddrStr)))
+	bin = append(bin, []uint8(serverAddrStr)...)
+
+	if len(stamp.Hashes) == 0 {
+		bin = append(bin, uint8(0))
+	} else {
+		last := len(stamp.Hashes) - 1
+		for i, hash := range stamp.Hashes {
+			vlen := len(hash)
+			if i < last {
+				vlen |= 0x80
+			}
+			bin = append(bin, uint8(vlen))
+			bin = append(bin, hash...)
+		}
+	}
+
+	bin = append(bin, uint8(len(stamp.ProviderName)))
+	bin = append(bin, []uint8(stamp.ProviderName)...)
+
+	// Serialize optional bootstrap IP addresses (VLP format)
+	if len(stamp.BootstrapIPs) > 0 {
+		last := len(stamp.BootstrapIPs) - 1
+		for i, bootstrapIP := range stamp.BootstrapIPs {
+			vlen := len(bootstrapIP)
+			if i < last {
+				vlen |= 0x80
+			}
+			bin = append(bin, uint8(vlen))
+			bin = append(bin, []uint8(bootstrapIP)...)
+		}
+	}
+
 	str := base64.RawURLEncoding.EncodeToString(bin)
 
 	return StampScheme + str
@@ -647,6 +1001,19 @@ func (stamp *ServerStamp) oDohRelayString() string {
 
 	bin = append(bin, uint8(len(stamp.Path)))
 	bin = append(bin, []uint8(stamp.Path)...)
+
+	// Serialize optional bootstrap IP addresses (VLP format)
+	if len(stamp.BootstrapIPs) > 0 {
+		last := len(stamp.BootstrapIPs) - 1
+		for i, bootstrapIP := range stamp.BootstrapIPs {
+			vlen := len(bootstrapIP)
+			if i < last {
+				vlen |= 0x80
+			}
+			bin = append(bin, uint8(vlen))
+			bin = append(bin, []uint8(bootstrapIP)...)
+		}
+	}
 
 	str := base64.RawURLEncoding.EncodeToString(bin)
 

--- a/dnsstamps_test.go
+++ b/dnsstamps_test.go
@@ -158,3 +158,733 @@ func TestPlainOldDNSWithPort(t *testing.T) {
 		t.Errorf("re-parsed stamp string is %q, but %q expected", ps, stamp)
 	}
 }
+
+func TestDNSOverTLS_Basic(t *testing.T) {
+	// [DNSSEC|No Filter|No Log] + 127.0.0.1 + hash + dns.example.com
+	const expected = `sdns://AwcAAAAAAAAACTEyNy4wLjAuMSDDhGvyS56TymQnTA7GfB7MXgJP_KzS10AZNQ6B_lRq5A9kbnMuZXhhbXBsZS5jb20`
+
+	var stamp ServerStamp
+	stamp.Props |= ServerInformalPropertyDNSSEC
+	stamp.Props |= ServerInformalPropertyNoLog
+	stamp.Props |= ServerInformalPropertyNoFilter
+	stamp.Proto = StampProtoTypeTLS
+	stamp.ServerAddrStr = "127.0.0.1"
+	stamp.ProviderName = "dns.example.com"
+	stamp.Hashes = [][]uint8{pk1}
+	stampStr := stamp.String()
+
+	if stampStr != expected {
+		t.Errorf("expected stamp %q but got instead %q", expected, stampStr)
+	}
+
+	parsedStamp, err := NewServerStampFromString(stampStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ps := parsedStamp.String()
+	if ps != stampStr {
+		t.Errorf("re-parsed stamp string is %q, but %q expected", ps, stampStr)
+	}
+}
+
+func TestDNSOverTLS_DefaultPort(t *testing.T) {
+	// Test that default port 853 is added correctly
+	var stamp ServerStamp
+	stamp.Proto = StampProtoTypeTLS
+	stamp.ServerAddrStr = "1.1.1.1"
+	stamp.ProviderName = "cloudflare-dns.com"
+	stamp.Hashes = [][]uint8{pk1}
+
+	stampStr := stamp.String()
+	parsedStamp, err := NewServerStampFromString(stampStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should have default port 853 added
+	if parsedStamp.ServerAddrStr != "1.1.1.1:853" {
+		t.Errorf("expected server address 1.1.1.1:853 but got %q", parsedStamp.ServerAddrStr)
+	}
+
+	ps := parsedStamp.String()
+	if ps != stampStr {
+		t.Errorf("re-parsed stamp string is %q, but %q expected", ps, stampStr)
+	}
+}
+
+func TestDNSOverTLS_CustomPort(t *testing.T) {
+	// Test with custom port 8853
+	const expected = `sdns://AwcAAAAAAAAADDEuMS4xLjE6ODg1MyDDhGvyS56TymQnTA7GfB7MXgJP_KzS10AZNQ6B_lRq5BJjbG91ZGZsYXJlLWRucy5jb20`
+
+	var stamp ServerStamp
+	stamp.Props |= ServerInformalPropertyDNSSEC
+	stamp.Props |= ServerInformalPropertyNoLog
+	stamp.Props |= ServerInformalPropertyNoFilter
+	stamp.Proto = StampProtoTypeTLS
+	stamp.ServerAddrStr = "1.1.1.1:8853"
+	stamp.ProviderName = "cloudflare-dns.com"
+	stamp.Hashes = [][]uint8{pk1}
+	stampStr := stamp.String()
+
+	if stampStr != expected {
+		t.Errorf("expected stamp %q but got instead %q", expected, stampStr)
+	}
+
+	parsedStamp, err := NewServerStampFromString(stampStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsedStamp.ServerAddrStr != "1.1.1.1:8853" {
+		t.Errorf("expected server address 1.1.1.1:8853 but got %q", parsedStamp.ServerAddrStr)
+	}
+	ps := parsedStamp.String()
+	if ps != stampStr {
+		t.Errorf("re-parsed stamp string is %q, but %q expected", ps, stampStr)
+	}
+}
+
+func TestDNSOverTLS_NoHashes(t *testing.T) {
+	// Test DoT stamp without certificate hashes
+	var stamp ServerStamp
+	stamp.Proto = StampProtoTypeTLS
+	stamp.ServerAddrStr = "9.9.9.9"
+	stamp.ProviderName = "dns.quad9.net"
+	stamp.Props = ServerInformalPropertyDNSSEC | ServerInformalPropertyNoFilter
+
+	stampStr := stamp.String()
+	parsedStamp, err := NewServerStampFromString(stampStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify parsed stamp matches original
+	if parsedStamp.Proto != StampProtoTypeTLS {
+		t.Errorf("expected proto TLS but got %v", parsedStamp.Proto)
+	}
+	if parsedStamp.ServerAddrStr != "9.9.9.9:853" {
+		t.Errorf("expected server address 9.9.9.9:853 but got %q", parsedStamp.ServerAddrStr)
+	}
+	if parsedStamp.ProviderName != "dns.quad9.net" {
+		t.Errorf("expected provider name dns.quad9.net but got %q", parsedStamp.ProviderName)
+	}
+	if len(parsedStamp.Hashes) != 0 {
+		t.Errorf("expected no hashes but got %d", len(parsedStamp.Hashes))
+	}
+
+	ps := parsedStamp.String()
+	if ps != stampStr {
+		t.Errorf("re-parsed stamp string is %q, but %q expected", ps, stampStr)
+	}
+}
+
+func TestDNSOverTLS_MultipleHashes(t *testing.T) {
+	// Test with multiple certificate hashes
+	hash1 := pk1
+	hash2 := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+		0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+		0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20}
+
+	var stamp ServerStamp
+	stamp.Proto = StampProtoTypeTLS
+	stamp.ServerAddrStr = "8.8.8.8"
+	stamp.ProviderName = "dns.google"
+	stamp.Hashes = [][]uint8{hash1, hash2}
+	stamp.Props = ServerInformalPropertyDNSSEC
+
+	stampStr := stamp.String()
+	parsedStamp, err := NewServerStampFromString(stampStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify multiple hashes were parsed correctly
+	if len(parsedStamp.Hashes) != 2 {
+		t.Errorf("expected 2 hashes but got %d", len(parsedStamp.Hashes))
+	}
+	if len(parsedStamp.Hashes[0]) != 32 {
+		t.Errorf("expected first hash to be 32 bytes but got %d", len(parsedStamp.Hashes[0]))
+	}
+	if len(parsedStamp.Hashes[1]) != 32 {
+		t.Errorf("expected second hash to be 32 bytes but got %d", len(parsedStamp.Hashes[1]))
+	}
+
+	ps := parsedStamp.String()
+	if ps != stampStr {
+		t.Errorf("re-parsed stamp string is %q, but %q expected", ps, stampStr)
+	}
+}
+
+func TestDNSOverTLS_IPv6(t *testing.T) {
+	// Test with IPv6 address
+	var stamp ServerStamp
+	stamp.Proto = StampProtoTypeTLS
+	stamp.ServerAddrStr = "[2001:4860:4860::8888]"
+	stamp.ProviderName = "dns.google"
+	stamp.Hashes = [][]uint8{pk1}
+	stamp.Props = ServerInformalPropertyDNSSEC
+
+	stampStr := stamp.String()
+	parsedStamp, err := NewServerStampFromString(stampStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should have default port 853 added
+	if parsedStamp.ServerAddrStr != "[2001:4860:4860::8888]:853" {
+		t.Errorf("expected server address [2001:4860:4860::8888]:853 but got %q", parsedStamp.ServerAddrStr)
+	}
+
+	ps := parsedStamp.String()
+	if ps != stampStr {
+		t.Errorf("re-parsed stamp string is %q, but %q expected", ps, stampStr)
+	}
+}
+
+func TestDNSOverTLS_AllProps(t *testing.T) {
+	// Test with all properties set
+	var stamp ServerStamp
+	stamp.Props = ServerInformalPropertyDNSSEC | ServerInformalPropertyNoLog | ServerInformalPropertyNoFilter
+	stamp.Proto = StampProtoTypeTLS
+	stamp.ServerAddrStr = "1.0.0.1"
+	stamp.ProviderName = "one.one.one.one"
+	stamp.Hashes = [][]uint8{pk1}
+
+	stampStr := stamp.String()
+	parsedStamp, err := NewServerStampFromString(stampStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify all properties were preserved
+	if parsedStamp.Props != stamp.Props {
+		t.Errorf("expected props %v but got %v", stamp.Props, parsedStamp.Props)
+	}
+
+	ps := parsedStamp.String()
+	if ps != stampStr {
+		t.Errorf("re-parsed stamp string is %q, but %q expected", ps, stampStr)
+	}
+}
+
+func TestDNSOverQUIC_Basic(t *testing.T) {
+	// [DNSSEC|No Filter|No Log] + 127.0.0.1 + hash + dns.example.com
+	const expected = `sdns://BAcAAAAAAAAACTEyNy4wLjAuMSDDhGvyS56TymQnTA7GfB7MXgJP_KzS10AZNQ6B_lRq5A9kbnMuZXhhbXBsZS5jb20`
+
+	var stamp ServerStamp
+	stamp.Props |= ServerInformalPropertyDNSSEC
+	stamp.Props |= ServerInformalPropertyNoLog
+	stamp.Props |= ServerInformalPropertyNoFilter
+	stamp.Proto = StampProtoTypeDoQ
+	stamp.ServerAddrStr = "127.0.0.1"
+	stamp.ProviderName = "dns.example.com"
+	stamp.Hashes = [][]uint8{pk1}
+	stampStr := stamp.String()
+
+	if stampStr != expected {
+		t.Errorf("expected stamp %q but got instead %q", expected, stampStr)
+	}
+
+	parsedStamp, err := NewServerStampFromString(stampStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ps := parsedStamp.String()
+	if ps != stampStr {
+		t.Errorf("re-parsed stamp string is %q, but %q expected", ps, stampStr)
+	}
+}
+
+func TestDNSOverQUIC_DefaultPort(t *testing.T) {
+	// Test that default port 853 is added correctly
+	var stamp ServerStamp
+	stamp.Proto = StampProtoTypeDoQ
+	stamp.ServerAddrStr = "1.1.1.1"
+	stamp.ProviderName = "cloudflare-dns.com"
+	stamp.Hashes = [][]uint8{pk1}
+
+	stampStr := stamp.String()
+	parsedStamp, err := NewServerStampFromString(stampStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should have default port 853 added
+	if parsedStamp.ServerAddrStr != "1.1.1.1:853" {
+		t.Errorf("expected server address 1.1.1.1:853 but got %q", parsedStamp.ServerAddrStr)
+	}
+
+	ps := parsedStamp.String()
+	if ps != stampStr {
+		t.Errorf("re-parsed stamp string is %q, but %q expected", ps, stampStr)
+	}
+}
+
+func TestDNSOverQUIC_CustomPort(t *testing.T) {
+	// Test with custom port 8853
+	const expected = `sdns://BAcAAAAAAAAADDEuMS4xLjE6ODg1MyDDhGvyS56TymQnTA7GfB7MXgJP_KzS10AZNQ6B_lRq5BJjbG91ZGZsYXJlLWRucy5jb20`
+
+	var stamp ServerStamp
+	stamp.Props |= ServerInformalPropertyDNSSEC
+	stamp.Props |= ServerInformalPropertyNoLog
+	stamp.Props |= ServerInformalPropertyNoFilter
+	stamp.Proto = StampProtoTypeDoQ
+	stamp.ServerAddrStr = "1.1.1.1:8853"
+	stamp.ProviderName = "cloudflare-dns.com"
+	stamp.Hashes = [][]uint8{pk1}
+	stampStr := stamp.String()
+
+	if stampStr != expected {
+		t.Errorf("expected stamp %q but got instead %q", expected, stampStr)
+	}
+
+	parsedStamp, err := NewServerStampFromString(stampStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if parsedStamp.ServerAddrStr != "1.1.1.1:8853" {
+		t.Errorf("expected server address 1.1.1.1:8853 but got %q", parsedStamp.ServerAddrStr)
+	}
+	ps := parsedStamp.String()
+	if ps != stampStr {
+		t.Errorf("re-parsed stamp string is %q, but %q expected", ps, stampStr)
+	}
+}
+
+func TestDNSOverQUIC_NoHashes(t *testing.T) {
+	// Test DoQ stamp without certificate hashes
+	var stamp ServerStamp
+	stamp.Proto = StampProtoTypeDoQ
+	stamp.ServerAddrStr = "9.9.9.9"
+	stamp.ProviderName = "dns.quad9.net"
+	stamp.Props = ServerInformalPropertyDNSSEC | ServerInformalPropertyNoFilter
+
+	stampStr := stamp.String()
+	parsedStamp, err := NewServerStampFromString(stampStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify parsed stamp matches original
+	if parsedStamp.Proto != StampProtoTypeDoQ {
+		t.Errorf("expected proto DoQ but got %v", parsedStamp.Proto)
+	}
+	if parsedStamp.ServerAddrStr != "9.9.9.9:853" {
+		t.Errorf("expected server address 9.9.9.9:853 but got %q", parsedStamp.ServerAddrStr)
+	}
+	if parsedStamp.ProviderName != "dns.quad9.net" {
+		t.Errorf("expected provider name dns.quad9.net but got %q", parsedStamp.ProviderName)
+	}
+	if len(parsedStamp.Hashes) != 0 {
+		t.Errorf("expected no hashes but got %d", len(parsedStamp.Hashes))
+	}
+
+	ps := parsedStamp.String()
+	if ps != stampStr {
+		t.Errorf("re-parsed stamp string is %q, but %q expected", ps, stampStr)
+	}
+}
+
+func TestDNSOverQUIC_MultipleHashes(t *testing.T) {
+	// Test with multiple certificate hashes
+	hash1 := pk1
+	hash2 := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+		0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10,
+		0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+		0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F, 0x20}
+
+	var stamp ServerStamp
+	stamp.Proto = StampProtoTypeDoQ
+	stamp.ServerAddrStr = "8.8.8.8"
+	stamp.ProviderName = "dns.google"
+	stamp.Hashes = [][]uint8{hash1, hash2}
+	stamp.Props = ServerInformalPropertyDNSSEC
+
+	stampStr := stamp.String()
+	parsedStamp, err := NewServerStampFromString(stampStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify multiple hashes were parsed correctly
+	if len(parsedStamp.Hashes) != 2 {
+		t.Errorf("expected 2 hashes but got %d", len(parsedStamp.Hashes))
+	}
+	if len(parsedStamp.Hashes[0]) != 32 {
+		t.Errorf("expected first hash to be 32 bytes but got %d", len(parsedStamp.Hashes[0]))
+	}
+	if len(parsedStamp.Hashes[1]) != 32 {
+		t.Errorf("expected second hash to be 32 bytes but got %d", len(parsedStamp.Hashes[1]))
+	}
+
+	ps := parsedStamp.String()
+	if ps != stampStr {
+		t.Errorf("re-parsed stamp string is %q, but %q expected", ps, stampStr)
+	}
+}
+
+func TestDNSOverQUIC_IPv6(t *testing.T) {
+	// Test with IPv6 address
+	var stamp ServerStamp
+	stamp.Proto = StampProtoTypeDoQ
+	stamp.ServerAddrStr = "[2001:4860:4860::8888]"
+	stamp.ProviderName = "dns.google"
+	stamp.Hashes = [][]uint8{pk1}
+	stamp.Props = ServerInformalPropertyDNSSEC
+
+	stampStr := stamp.String()
+	parsedStamp, err := NewServerStampFromString(stampStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should have default port 853 added
+	if parsedStamp.ServerAddrStr != "[2001:4860:4860::8888]:853" {
+		t.Errorf("expected server address [2001:4860:4860::8888]:853 but got %q", parsedStamp.ServerAddrStr)
+	}
+
+	ps := parsedStamp.String()
+	if ps != stampStr {
+		t.Errorf("re-parsed stamp string is %q, but %q expected", ps, stampStr)
+	}
+}
+
+func TestDNSOverQUIC_AllProps(t *testing.T) {
+	// Test with all properties set
+	var stamp ServerStamp
+	stamp.Props = ServerInformalPropertyDNSSEC | ServerInformalPropertyNoLog | ServerInformalPropertyNoFilter
+	stamp.Proto = StampProtoTypeDoQ
+	stamp.ServerAddrStr = "1.0.0.1"
+	stamp.ProviderName = "one.one.one.one"
+	stamp.Hashes = [][]uint8{pk1}
+
+	stampStr := stamp.String()
+	parsedStamp, err := NewServerStampFromString(stampStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify all properties were preserved
+	if parsedStamp.Props != stamp.Props {
+		t.Errorf("expected props %v but got %v", stamp.Props, parsedStamp.Props)
+	}
+
+	ps := parsedStamp.String()
+	if ps != stampStr {
+		t.Errorf("re-parsed stamp string is %q, but %q expected", ps, stampStr)
+	}
+}
+
+// Bootstrap IP address tests for DoT
+
+func TestDNSOverTLS_SingleBootstrapIP(t *testing.T) {
+	// Test DoT stamp with single bootstrap IP address
+	var stamp ServerStamp
+	stamp.Props = ServerInformalPropertyDNSSEC
+	stamp.Proto = StampProtoTypeTLS
+	stamp.ServerAddrStr = "1.1.1.1"
+	stamp.ProviderName = "cloudflare-dns.com"
+	stamp.Hashes = [][]uint8{pk1}
+	stamp.BootstrapIPs = []string{"1.1.1.1"}
+
+	stampStr := stamp.String()
+	parsedStamp, err := NewServerStampFromString(stampStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify bootstrap IPs were parsed correctly
+	if len(parsedStamp.BootstrapIPs) != 1 {
+		t.Errorf("expected 1 bootstrap IP but got %d", len(parsedStamp.BootstrapIPs))
+	}
+	if parsedStamp.BootstrapIPs[0] != "1.1.1.1" {
+		t.Errorf("expected bootstrap IP 1.1.1.1 but got %q", parsedStamp.BootstrapIPs[0])
+	}
+
+	ps := parsedStamp.String()
+	if ps != stampStr {
+		t.Errorf("re-parsed stamp string is %q, but %q expected", ps, stampStr)
+	}
+}
+
+func TestDNSOverTLS_MultipleBootstrapIPs(t *testing.T) {
+	// Test with multiple bootstrap IP addresses (IPv4 and IPv6)
+	var stamp ServerStamp
+	stamp.Props = ServerInformalPropertyDNSSEC | ServerInformalPropertyNoLog
+	stamp.Proto = StampProtoTypeTLS
+	stamp.ServerAddrStr = "9.9.9.9"
+	stamp.ProviderName = "dns.quad9.net"
+	stamp.Hashes = [][]uint8{pk1}
+	stamp.BootstrapIPs = []string{"9.9.9.9", "149.112.112.112", "2620:fe::fe"}
+
+	stampStr := stamp.String()
+	parsedStamp, err := NewServerStampFromString(stampStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify all bootstrap IPs were parsed correctly
+	if len(parsedStamp.BootstrapIPs) != 3 {
+		t.Errorf("expected 3 bootstrap IPs but got %d", len(parsedStamp.BootstrapIPs))
+	}
+	expectedIPs := []string{"9.9.9.9", "149.112.112.112", "2620:fe::fe"}
+	for i, expectedIP := range expectedIPs {
+		if parsedStamp.BootstrapIPs[i] != expectedIP {
+			t.Errorf("expected bootstrap IP %q at index %d but got %q", expectedIP, i, parsedStamp.BootstrapIPs[i])
+		}
+	}
+
+	ps := parsedStamp.String()
+	if ps != stampStr {
+		t.Errorf("re-parsed stamp string is %q, but %q expected", ps, stampStr)
+	}
+}
+
+func TestDNSOverTLS_BootstrapIPsWithAllProps(t *testing.T) {
+	// Test with bootstrap IPs and all properties
+	var stamp ServerStamp
+	stamp.Props = ServerInformalPropertyDNSSEC | ServerInformalPropertyNoLog | ServerInformalPropertyNoFilter
+	stamp.Proto = StampProtoTypeTLS
+	stamp.ServerAddrStr = "8.8.8.8:8853"
+	stamp.ProviderName = "dns.google"
+	stamp.Hashes = [][]uint8{pk1}
+	stamp.BootstrapIPs = []string{"8.8.8.8", "8.8.4.4"}
+
+	stampStr := stamp.String()
+	parsedStamp, err := NewServerStampFromString(stampStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify all fields were preserved
+	if parsedStamp.Props != stamp.Props {
+		t.Errorf("expected props %v but got %v", stamp.Props, parsedStamp.Props)
+	}
+	if parsedStamp.ServerAddrStr != "8.8.8.8:8853" {
+		t.Errorf("expected server address 8.8.8.8:8853 but got %q", parsedStamp.ServerAddrStr)
+	}
+	if len(parsedStamp.BootstrapIPs) != 2 {
+		t.Errorf("expected 2 bootstrap IPs but got %d", len(parsedStamp.BootstrapIPs))
+	}
+
+	ps := parsedStamp.String()
+	if ps != stampStr {
+		t.Errorf("re-parsed stamp string is %q, but %q expected", ps, stampStr)
+	}
+}
+
+func TestDNSOverTLS_NoBootstrapIPs_BackwardCompatibility(t *testing.T) {
+	// Test that DoT stamps without bootstrap IPs still work (backward compatibility)
+	var stamp ServerStamp
+	stamp.Props = ServerInformalPropertyDNSSEC
+	stamp.Proto = StampProtoTypeTLS
+	stamp.ServerAddrStr = "1.0.0.1"
+	stamp.ProviderName = "one.one.one.one"
+	stamp.Hashes = [][]uint8{pk1}
+	// No bootstrap IPs set
+
+	stampStr := stamp.String()
+	parsedStamp, err := NewServerStampFromString(stampStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify no bootstrap IPs
+	if len(parsedStamp.BootstrapIPs) != 0 {
+		t.Errorf("expected 0 bootstrap IPs but got %d", len(parsedStamp.BootstrapIPs))
+	}
+
+	ps := parsedStamp.String()
+	if ps != stampStr {
+		t.Errorf("re-parsed stamp string is %q, but %q expected", ps, stampStr)
+	}
+}
+
+func TestDNSOverTLS_BootstrapIPv6Only(t *testing.T) {
+	// Test with IPv6-only bootstrap addresses
+	var stamp ServerStamp
+	stamp.Proto = StampProtoTypeTLS
+	stamp.ServerAddrStr = "[2606:4700:4700::1111]"
+	stamp.ProviderName = "cloudflare-dns.com"
+	stamp.Hashes = [][]uint8{pk1}
+	stamp.BootstrapIPs = []string{"2606:4700:4700::1111", "2606:4700:4700::1001"}
+
+	stampStr := stamp.String()
+	parsedStamp, err := NewServerStampFromString(stampStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify IPv6 bootstrap IPs
+	if len(parsedStamp.BootstrapIPs) != 2 {
+		t.Errorf("expected 2 bootstrap IPs but got %d", len(parsedStamp.BootstrapIPs))
+	}
+	if parsedStamp.BootstrapIPs[0] != "2606:4700:4700::1111" {
+		t.Errorf("expected first bootstrap IP 2606:4700:4700::1111 but got %q", parsedStamp.BootstrapIPs[0])
+	}
+	if parsedStamp.BootstrapIPs[1] != "2606:4700:4700::1001" {
+		t.Errorf("expected second bootstrap IP 2606:4700:4700::1001 but got %q", parsedStamp.BootstrapIPs[1])
+	}
+
+	ps := parsedStamp.String()
+	if ps != stampStr {
+		t.Errorf("re-parsed stamp string is %q, but %q expected", ps, stampStr)
+	}
+}
+
+// Bootstrap IP address tests for DoQ
+
+func TestDNSOverQUIC_SingleBootstrapIP(t *testing.T) {
+	// Test DoQ stamp with single bootstrap IP address
+	var stamp ServerStamp
+	stamp.Props = ServerInformalPropertyDNSSEC
+	stamp.Proto = StampProtoTypeDoQ
+	stamp.ServerAddrStr = "1.1.1.1"
+	stamp.ProviderName = "cloudflare-dns.com"
+	stamp.Hashes = [][]uint8{pk1}
+	stamp.BootstrapIPs = []string{"1.1.1.1"}
+
+	stampStr := stamp.String()
+	parsedStamp, err := NewServerStampFromString(stampStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify bootstrap IPs were parsed correctly
+	if len(parsedStamp.BootstrapIPs) != 1 {
+		t.Errorf("expected 1 bootstrap IP but got %d", len(parsedStamp.BootstrapIPs))
+	}
+	if parsedStamp.BootstrapIPs[0] != "1.1.1.1" {
+		t.Errorf("expected bootstrap IP 1.1.1.1 but got %q", parsedStamp.BootstrapIPs[0])
+	}
+
+	ps := parsedStamp.String()
+	if ps != stampStr {
+		t.Errorf("re-parsed stamp string is %q, but %q expected", ps, stampStr)
+	}
+}
+
+func TestDNSOverQUIC_MultipleBootstrapIPs(t *testing.T) {
+	// Test with multiple bootstrap IP addresses (IPv4 and IPv6)
+	var stamp ServerStamp
+	stamp.Props = ServerInformalPropertyDNSSEC | ServerInformalPropertyNoLog
+	stamp.Proto = StampProtoTypeDoQ
+	stamp.ServerAddrStr = "9.9.9.9"
+	stamp.ProviderName = "dns.quad9.net"
+	stamp.Hashes = [][]uint8{pk1}
+	stamp.BootstrapIPs = []string{"9.9.9.9", "149.112.112.112", "2620:fe::fe"}
+
+	stampStr := stamp.String()
+	parsedStamp, err := NewServerStampFromString(stampStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify all bootstrap IPs were parsed correctly
+	if len(parsedStamp.BootstrapIPs) != 3 {
+		t.Errorf("expected 3 bootstrap IPs but got %d", len(parsedStamp.BootstrapIPs))
+	}
+	expectedIPs := []string{"9.9.9.9", "149.112.112.112", "2620:fe::fe"}
+	for i, expectedIP := range expectedIPs {
+		if parsedStamp.BootstrapIPs[i] != expectedIP {
+			t.Errorf("expected bootstrap IP %q at index %d but got %q", expectedIP, i, parsedStamp.BootstrapIPs[i])
+		}
+	}
+
+	ps := parsedStamp.String()
+	if ps != stampStr {
+		t.Errorf("re-parsed stamp string is %q, but %q expected", ps, stampStr)
+	}
+}
+
+func TestDNSOverQUIC_BootstrapIPsWithAllProps(t *testing.T) {
+	// Test with bootstrap IPs and all properties
+	var stamp ServerStamp
+	stamp.Props = ServerInformalPropertyDNSSEC | ServerInformalPropertyNoLog | ServerInformalPropertyNoFilter
+	stamp.Proto = StampProtoTypeDoQ
+	stamp.ServerAddrStr = "8.8.8.8:8853"
+	stamp.ProviderName = "dns.google"
+	stamp.Hashes = [][]uint8{pk1}
+	stamp.BootstrapIPs = []string{"8.8.8.8", "8.8.4.4"}
+
+	stampStr := stamp.String()
+	parsedStamp, err := NewServerStampFromString(stampStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify all fields were preserved
+	if parsedStamp.Props != stamp.Props {
+		t.Errorf("expected props %v but got %v", stamp.Props, parsedStamp.Props)
+	}
+	if parsedStamp.ServerAddrStr != "8.8.8.8:8853" {
+		t.Errorf("expected server address 8.8.8.8:8853 but got %q", parsedStamp.ServerAddrStr)
+	}
+	if len(parsedStamp.BootstrapIPs) != 2 {
+		t.Errorf("expected 2 bootstrap IPs but got %d", len(parsedStamp.BootstrapIPs))
+	}
+
+	ps := parsedStamp.String()
+	if ps != stampStr {
+		t.Errorf("re-parsed stamp string is %q, but %q expected", ps, stampStr)
+	}
+}
+
+func TestDNSOverQUIC_NoBootstrapIPs_BackwardCompatibility(t *testing.T) {
+	// Test that DoQ stamps without bootstrap IPs still work (backward compatibility)
+	var stamp ServerStamp
+	stamp.Props = ServerInformalPropertyDNSSEC
+	stamp.Proto = StampProtoTypeDoQ
+	stamp.ServerAddrStr = "1.0.0.1"
+	stamp.ProviderName = "one.one.one.one"
+	stamp.Hashes = [][]uint8{pk1}
+	// No bootstrap IPs set
+
+	stampStr := stamp.String()
+	parsedStamp, err := NewServerStampFromString(stampStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify no bootstrap IPs
+	if len(parsedStamp.BootstrapIPs) != 0 {
+		t.Errorf("expected 0 bootstrap IPs but got %d", len(parsedStamp.BootstrapIPs))
+	}
+
+	ps := parsedStamp.String()
+	if ps != stampStr {
+		t.Errorf("re-parsed stamp string is %q, but %q expected", ps, stampStr)
+	}
+}
+
+func TestDNSOverQUIC_BootstrapIPv6Only(t *testing.T) {
+	// Test with IPv6-only bootstrap addresses
+	var stamp ServerStamp
+	stamp.Proto = StampProtoTypeDoQ
+	stamp.ServerAddrStr = "[2606:4700:4700::1111]"
+	stamp.ProviderName = "cloudflare-dns.com"
+	stamp.Hashes = [][]uint8{pk1}
+	stamp.BootstrapIPs = []string{"2606:4700:4700::1111", "2606:4700:4700::1001"}
+
+	stampStr := stamp.String()
+	parsedStamp, err := NewServerStampFromString(stampStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify IPv6 bootstrap IPs
+	if len(parsedStamp.BootstrapIPs) != 2 {
+		t.Errorf("expected 2 bootstrap IPs but got %d", len(parsedStamp.BootstrapIPs))
+	}
+	if parsedStamp.BootstrapIPs[0] != "2606:4700:4700::1111" {
+		t.Errorf("expected first bootstrap IP 2606:4700:4700::1111 but got %q", parsedStamp.BootstrapIPs[0])
+	}
+	if parsedStamp.BootstrapIPs[1] != "2606:4700:4700::1001" {
+		t.Errorf("expected second bootstrap IP 2606:4700:4700::1001 but got %q", parsedStamp.BootstrapIPs[1])
+	}
+
+	ps := parsedStamp.String()
+	if ps != stampStr {
+		t.Errorf("re-parsed stamp string is %q, but %q expected", ps, stampStr)
+	}
+}


### PR DESCRIPTION
- Implement DoT (DNS-over-TLS) parsing and serialization
- Implement DoQ (DNS-over-QUIC) parsing and serialization
- Add proper default port handling for DoT/DoQ (853 instead of 443)
- Implement bootstrap IP address parsing/serialization for DoT, DoQ, DoH, and ODoH Relay

Implements https://www.ietf.org/archive/id/draft-denis-dns-stamps-00.txt sections for DoT and DoQ protocols